### PR TITLE
Update AVR toolchain to 1.8.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Compile Arduino AVR programs using CMake.
 
 1. Clone this repository and open a terminal in the `Arduino-AVR-CMake` folder.
 2. Ensure that the Arduino AVR core is installed correctly, this guide assumes
-   that the core is in `~/.arduino15/packages/arduino/hardware/avr/1.8.5`,
+   that the core is in `~/.arduino15/packages/arduino/hardware/avr/1.8.6`,
    that the toolchain is in `~/.arduino15/packages/arduino/tools/avr-gcc/7.3.0-atmel3.6.1-arduino7`,
    and that avrdude is in `~/.arduino15/packages/arduino/tools/avrdude/6.3.0-arduino17`.
    If this is not the case, change it now in `cmake/toolchain/avr.toolchain.cmake`.

--- a/cmake/toolchain/avr.toolchain.cmake
+++ b/cmake/toolchain/avr.toolchain.cmake
@@ -1,7 +1,7 @@
 set(CMAKE_SYSTEM_PROCESSOR avr)
 
 set(ARDUINO_PATH $ENV{HOME}/.arduino15/packages/arduino)
-set(ARDUINO_AVR_PATH ${ARDUINO_PATH}/hardware/avr/1.8.5)
+set(ARDUINO_AVR_PATH ${ARDUINO_PATH}/hardware/avr/1.8.6)
 set(ARDUINO_CORE_PATH ${ARDUINO_AVR_PATH}/cores/arduino)
 set(ARDUINO_TOOLS_PATH ${ARDUINO_PATH}/tools/avr-gcc/7.3.0-atmel3.6.1-arduino7/bin)
 set(ARDUINO_AVRDUDE_PATH ${ARDUINO_PATH}/tools/avrdude/6.3.0-arduino17)


### PR DESCRIPTION
Modify `README.md` to reference new AVR toolchain version
Modify `avr.toolchain.cmake` to include AVR toolchain version 1.8.6