### PR TITLE
Add support for libraries arduino supply by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to the project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+All dates in this file follow [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html).
+
+## [Unreleased]
+
+### Added
+- Include Arduino bundled libraries ([#1](https://github.com/wanzenried/Arduino-AVR-CMake/pull/1))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,19 @@ include(cmake/lto.cmake)
 include(cmake/arduino_core.cmake)
 include(cmake/arduino_hex.cmake)
 include(cmake/arduino_upload.cmake)
+include(cmake/arduino_libs.cmake)
 
 add_executable(blink blink.cpp)
-target_link_libraries(blink PUBLIC ArduinoCore)
+
+# Remove comments from libraries you wish to use
+target_link_libraries(blink PUBLIC 
+    ArduinoCore
+    #ArduinoEEPROM
+    #ArduinoHID
+    #ArduinoSPI
+    #ArduinoSoftSerial
+    #ArduinoWire
+)
 target_compile_options(blink PRIVATE
     "-Wall"
     "-Wextra"

--- a/cmake/arduino_libs.cmake
+++ b/cmake/arduino_libs.cmake
@@ -1,0 +1,47 @@
+# Adds libraries included by default in arduino installs
+
+set(ARDUINO_LIB_PATH ${ARDUINO_AVR_PATH}/libraries)
+
+# EEPROM
+add_library(ArduinoEEPROM INTERFACE)
+target_include_directories(ArduinoEEPROM INTERFACE
+    ${ARDUINO_LIB_PATH}/EEPROM/src
+)
+target_link_libraries(ArduinoEEPROM INTERFACE ArduinoCore)
+
+# HID
+add_library(ArduinoHID STATIC
+    ${ARDUINO_LIB_PATH}/HID/src/HID.cpp
+)
+target_include_directories(ArduinoHID PUBLIC
+    ${ARDUINO_LIB_PATH}/HID/src
+)
+target_link_libraries(ArduinoHID PUBLIC ArduinoCore)
+
+# SPI
+add_library(ArduinoSPI STATIC
+    ${ARDUINO_LIB_PATH}/SPI/src/SPI.cpp
+)
+target_include_directories(ArduinoSPI PUBLIC
+    ${ARDUINO_LIB_PATH}/SPI/src
+)
+target_link_libraries(ArduinoSPI PUBLIC ArduinoCore)
+
+# SoftwareSerial
+add_library(ArduinoSoftSerial STATIC
+    ${ARDUINO_LIB_PATH}/SoftwareSerial/src/SoftwareSerial.cpp
+)
+target_include_directories(ArduinoSoftSerial PUBLIC
+    ${ARDUINO_LIB_PATH}/SoftwareSerial/src
+)
+target_link_libraries(ArduinoSoftSerial PUBLIC ArduinoCore)
+
+# Wire
+add_library(ArduinoWire STATIC
+    ${ARDUINO_LIB_PATH}/Wire/src/Wire.cpp
+    ${ARDUINO_LIB_PATH}/Wire/src/utility/twi.c
+)
+target_include_directories(ArduinoWire PUBLIC
+    ${ARDUINO_LIB_PATH}/Wire/src
+)
+target_link_libraries(ArduinoWire PUBLIC ArduinoCore)


### PR DESCRIPTION
This adds support for the 5 libraries that are bundled with [ArduinoCore-avr](https://github.com/arduino/ArduinoCore-avr/tree/master/libraries) by default:
- `EEPROM.h`
- `HID.h`
- `SPI.h`
- `SoftwareSerial.h`
- `Wire.h`

This is done via 5 libraries in a new .cmake file, which can then be included in the main CMakeLists.txt file if needed.